### PR TITLE
Bacalhau node section

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -105,7 +105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -358,6 +358,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-watcher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bacb0b348a5dc507de0234ae0627d09c6f5ca6d257a084872f01a294616b9517"
+dependencies = [
+ "async-trait",
+ "notify 5.2.0",
+ "serde",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,6 +434,22 @@ dependencies = [
  "rustversion",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "bacalhau"
+version = "0.1.0"
+dependencies = [
+ "arrow",
+ "arrow-json",
+ "async-watcher",
+ "futures",
+ "reqwest",
+ "section",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -536,7 +566,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -683,6 +713,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,7 +851,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -822,7 +862,7 @@ checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
 dependencies = [
  "cfg-if",
  "home",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -852,7 +892,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall 0.3.5",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -910,6 +950,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1163,7 +1212,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1336,7 +1385,7 @@ checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1602,7 +1651,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1656,6 +1705,24 @@ dependencies = [
 
 [[package]]
 name = "notify"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "729f63e1ca555a43fe3efa4f3efdf4801c479da85b432242a7b726f353c88486"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "mio",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "notify"
 version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
@@ -1668,7 +1735,7 @@ dependencies = [
  "log",
  "mio",
  "walkdir",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1875,7 +1942,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.4.1",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2226,6 +2293,8 @@ name = "runtime"
 version = "0.1.0"
 dependencies = [
  "arrow",
+ "async-watcher",
+ "bacalhau",
  "base64",
  "bytes",
  "futures",
@@ -2303,7 +2372,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2333,7 +2402,7 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2554,7 +2623,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2618,7 +2687,7 @@ version = "0.1.0"
 dependencies = [
  "fallible-iterator",
  "futures",
- "notify",
+ "notify 6.1.1",
  "section",
  "sqlite3-parser",
  "sqlx",
@@ -2637,7 +2706,7 @@ dependencies = [
  "arrow",
  "futures",
  "journal",
- "notify",
+ "notify 6.1.1",
  "section",
  "tokio",
  "tokio-stream",
@@ -2952,7 +3021,7 @@ dependencies = [
  "fastrand",
  "redox_syscall 0.3.5",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3024,7 +3093,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2 0.5.4",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3057,6 +3126,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -3456,7 +3526,16 @@ version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -3465,7 +3544,22 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -3474,14 +3568,20 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3491,9 +3591,21 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3503,9 +3615,21 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3515,9 +3639,21 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3541,7 +3677,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -43,6 +43,7 @@ pub enum Source {
     Snowflake(SnowflakeConfig),
     Sqlite_Physical_Replication(SqlitePhysicalReplicationSourceConfig),
     Hello_World(HelloWorldConfig),
+    Bacalhau(BacalhauConfig),
 }
 
 /// Internally-tagged type of a source needs to match the variant name
@@ -55,6 +56,7 @@ pub enum Destination {
     Sqlite_Physical_Replication(SqlitePhysicalReplicationDestinationConfig),
     Hello_World(HelloWorldConfig),
     Kafka(KafkaDestinationConfig),
+    Bacalhau(BacalhauConfig),
 }
 
 // Shared between all source definitions
@@ -116,6 +118,11 @@ pub struct HelloWorldConfig {
     pub common_attrs: CommonAttrs,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct BacalhauConfig {
+    #[serde(flatten)]
+    pub common_attrs: CommonAttrs,
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct KafkaDestinationConfig {

--- a/console/components/@types/client.d.ts
+++ b/console/components/@types/client.d.ts
@@ -10,12 +10,14 @@ type ISource =
   | IKafka
   | IPostgres
   | IHelloWorld
+  | IBacalhau
   | ISnowflake
   | IMyceliteSource
   | IMycelialNetwork;
 type IDestination =
   | ISqlite
   | IHelloWorld
+  | IBacalhau  
   | ISnowflake
   | IMyceliteDestination
   | IMycelialNetwork;
@@ -37,6 +39,13 @@ type ISqlite = {
 type IHelloWorld = {
   type: string;
   display_name: string;
+};
+
+type IBacalhau = {
+  type: string;
+  display_name: string;
+  job: string;
+  inputs: string;
 };
 
 type IKafka = {

--- a/console/components/Flow/index.tsx
+++ b/console/components/Flow/index.tsx
@@ -43,6 +43,9 @@ import {
   PostgresSourceNode,
   HelloWorldSourceNode,
   HelloWorldDestinationNode,
+  BacalhauNode,
+  BacalhauSourceNode,
+  BacalhauDestinationNode,
 } from "@/components/nodes";
 
 import { Grid, Group } from "@/components/layout";
@@ -70,11 +73,10 @@ const useStyles = createStyles((theme) => ({
     marginBottom: theme.spacing.md,
 
     "&:not(:last-of-type)": {
-      borderBottom: `${rem(1)} solid ${
-        theme.colorScheme === "dark"
-          ? theme.colors.dark[4]
-          : theme.colors.gray[3]
-      }`,
+      borderBottom: `${rem(1)} solid ${theme.colorScheme === "dark"
+        ? theme.colors.dark[4]
+        : theme.colors.gray[3]
+        }`,
     },
   },
 
@@ -181,6 +183,9 @@ const nodeTypes = {
   postgres_source: PostgresSourceNode,
   hello_world_source: HelloWorldSourceNode,
   hello_world_destination: HelloWorldDestinationNode,
+  bacalhau: BacalhauNode,
+  bacalhau_source: BacalhauSourceNode,
+  bacalhau_destination: BacalhauDestinationNode,
 };
 
 const defaultEdgeOptions = {
@@ -269,6 +274,13 @@ function NavbarSearch(props: NavbarSearchProps) {
       topic: getRandomString(),
     };
 
+    let bac_source = {
+      type: "bacalhau",
+      display_name: "Bacalhau",
+      endpoint: "http://localhost:2112/accept",
+      job: "Sample",
+    };
+
     return [
       <div
         key="mycelial_server"
@@ -276,7 +288,15 @@ function NavbarSearch(props: NavbarSearchProps) {
         onDragStart={(event) => onDragStart(event, null, source, source)}
         draggable
       >
-        Mycelial Server 
+        Mycelial Server
+      </div>,
+      <div
+        key="bacalhau"
+        className={classes.collectionLink}
+        onDragStart={(event) => onDragStart(event, null, bac_source, bac_source)}
+        draggable
+      >
+        Bacalhau Node
       </div>,
     ];
   };
@@ -335,7 +355,7 @@ async function getConfigs(token: string) {
     });
     const result = await response.json();
     return result;
-  } catch (error) {}
+  } catch (error) { }
 }
 
 const dagreGraph = new dagre.graphlib.Graph();
@@ -410,6 +430,13 @@ function Flow() {
           nodeType === "mycelial_server_destination"
         ) {
           nodeType = "mycelial_server";
+        }
+
+        if (
+          nodeType === "bacalhau_source" ||
+          nodeType === "bacalhaU_destination"
+        ) {
+          nodeType = "bacalhau";
         }
 
         let node: Node = {
@@ -521,6 +548,16 @@ function Flow() {
           name: "mycelial_server_destination",
           ...node.data,
         };
+      } else if (node?.type === "bacalhau" && kind === "source") {
+        return {
+          name: "bacalhau_source",
+          ...node.data,
+        };
+      } else if (node?.type === "bacalhau" && kind === "destination") {
+        return {
+          name: "bacalhau_destination",
+          ...node.data,
+        }
       } else if (node?.type) {
         return {
           name: node.type,
@@ -561,7 +598,7 @@ function Flow() {
 
       if (edge.data?.id) {
         let payload = {
-          configs: [{id: edge.data.id, pipe: pipe}]
+          configs: [{ id: edge.data.id, pipe: pipe }]
         }
         try {
           const response = await fetch("/api/pipe", {
@@ -580,7 +617,7 @@ function Flow() {
       } else {
         let id = 0;
         let payload = {
-          configs: [{id: 0, pipe: pipe}]
+          configs: [{ id: 0, pipe: pipe }]
         }
         const response = await fetch("/api/pipe", {
           method: "POST",
@@ -603,7 +640,7 @@ function Flow() {
                   id: id,
                 },
               }
-            } 
+            }
             return ed;
           });
         })

--- a/console/components/nodes.tsx
+++ b/console/components/nodes.tsx
@@ -16,6 +16,324 @@ import styles from "@/components/Flow/Flow.module.css";
 import { ClientContext } from "./context/clientContext";
 import { ClientContextType } from "./@types/client";
 
+const BacalhauNode: FC<NodeProps> = memo(({ id, data, selected }) => {
+  const instance = useReactFlow();
+  const { clients } = useContext(ClientContext) as ClientContextType;
+
+  let initialValues = useMemo(() => {
+    return {
+      client: data.client ? data.client : "...",
+      job: data.job ? data.job : "...",
+      endpoint: data.endpoint
+        ? data.endpoint
+        : "http://localhost:2112/accept",
+      outputs: data.outputs ? data.outputs : "",
+    };
+  }, []);
+
+  const removeNode = useCallback((id: string) => {
+    let node = instance.getNode(id);
+    if (node === undefined) {
+      return;
+    }
+    let edges = getConnectedEdges([node], []);
+    instance.deleteElements({ edges, nodes: [node] });
+  }, []);
+
+  const handleChange = useCallback((name: string, value: string) => {
+    instance.setNodes((nodes) =>
+      nodes.map((node) => {
+        if (node.id === id) {
+          node.data = {
+            ...node.data,
+            [name]: value,
+          };
+        }
+
+        return node;
+      }),
+    );
+  }, []);
+
+  useEffect(() => {
+    handleChange("client", initialValues.client);
+    handleChange("endpoint", initialValues.endpoint);
+    handleChange("job", initialValues.job);
+    handleChange("outputs", initialValues.outputs);
+  }, []);
+
+  let classNames = `${styles.customNode} `;
+  if (selected) {
+    classNames = classNames + `${styles.selected}`;
+  }
+  return (
+    <div className={classNames}>
+      <div className=" grid grid-cols-1 gap-x-6 gap-y-2">
+        <Handle type="target" position={Position.Left} id={id} />
+        <Handle type="source" position={Position.Right} id={id} />
+        <h2 className="text-slate-400 font-normal">Bacalhau Node</h2>
+
+        <button
+          onClick={() => {
+            if (confirm("Are you sure you want to delete this node?")) {
+              removeNode(id);
+            }
+          }}
+          type="button"
+          className="absolute right-1 top-1 rounded bg-red-200 text-white shadow-sm hover:bg-red-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-800"
+          title="delete"
+        >
+          <XMarkIcon className="h-5 w-5" aria-hidden="true" />
+        </button>
+        <Select
+          name="client"
+          label="Client"
+          placeholder="Pick one"
+          defaultValue={initialValues.client}
+          options={(clients || []).map((c) => c.id)}
+          onChange={(value) => {
+            handleChange("client", value || "");
+          }}
+        />
+        <Select
+          name="job"
+          label="Job"
+          placeholder="Pick one"
+          defaultValue={initialValues.job}
+          options={["Sample"]}
+          onChange={(value) => {
+            handleChange("job", value || "");
+          }}
+        />
+        <TextInput
+          name="endpoint"
+          label="Endpoint"
+          placeholder={initialValues.endpoint}
+          defaultValue={initialValues.endpoint}
+          onChange={(event) =>
+            handleChange("endpoint", event.currentTarget.value)
+          }
+        />
+        <TextInput
+          name="outputs"
+          label="Outputs"
+          placeholder={initialValues.outputs}
+          defaultValue={initialValues.outputs}
+          onChange={(event) =>
+            handleChange("outputs", event.currentTarget.value)
+          }
+        />
+
+      </div>
+    </div>
+  );
+});
+
+
+const BacalhauSourceNode: FC<NodeProps> = memo(({ id, data, selected }) => {
+  const instance = useReactFlow();
+  const { clients } = useContext(ClientContext) as ClientContextType;
+
+  let initialValues = useMemo(() => {
+    return {
+      client: data.client ? data.client : "-",
+      job: data.job ? data.job : "Sample",
+      endpoint: data.endpoint ? data.endpoint : "http://127.0.0.1:2112/accept",
+    };
+  }, []);
+
+  const handleChange = useCallback((name: string, value: string | number) => {
+    instance.setNodes((nodes) =>
+      nodes.map((node) => {
+        if (node.id === id) {
+          node.data = {
+            ...node.data,
+            [name]: value,
+          };
+        }
+
+        return node;
+      }),
+    );
+  }, []);
+
+  useEffect(() => {
+    handleChange("client", initialValues.client);
+    handleChange("job", initialValues.job);
+    handleChange("endpoint", initialValues.endpoint);
+  }, []);
+
+  let classNames = `${styles.customNode} `;
+  if (selected) {
+    classNames = classNames + `${styles.selected}`;
+  }
+
+  const removeNode = useCallback((id: string) => {
+    const node = instance.getNode(id);
+    if (node === undefined) {
+      return;
+    }
+    instance.deleteElements({
+      edges: getConnectedEdges([node], []),
+      nodes: [node],
+    });
+  }, []);
+
+  return (
+    <div className={classNames}>
+      <div className=" grid grid-cols-1 gap-x-6 gap-y-2">
+        <Handle type="target" position={Position.Left} id={id} />
+        <Handle type="source" position={Position.Right} id={id} />
+
+        <h2 className="text-slate-400 font-normal">Bacalhau Source</h2>
+        <button
+          onClick={() => {
+            if (confirm("Are you sure you want to delete this node?")) {
+              removeNode(id);
+            }
+          }}
+          type="button"
+          className="absolute right-1 top-1 rounded bg-red-200 text-white shadow-sm hover:bg-red-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-800"
+          title="delete"
+        >
+          <XMarkIcon className="h-5 w-5" aria-hidden="true" />
+        </button>
+        <Select
+          name="client"
+          label="Client"
+          placeholder="Pick one"
+          defaultValue={initialValues.client}
+          options={(clients || []).map((c) => c.id)}
+          onChange={(value) => {
+            handleChange("client", value || "");
+          }}
+        />
+        <Select
+          name="job"
+          label="Job"
+          placeholder="Pick one"
+          defaultValue={initialValues.job}
+          options={["Sample"]}
+          onChange={(value) => {
+            handleChange("job", value || "");
+          }}
+        />
+        <TextInput
+          name="endpoint"
+          label="Endpoint"
+          placeholder={initialValues.endpoint}
+          defaultValue={initialValues.endpoint}
+          onChange={(event) => {
+            handleChange("endpoint", event.currentTarget.value)
+          }}
+        />
+      </div>
+    </div>
+  );
+});
+
+const BacalhauDestinationNode: FC<NodeProps> = memo(({ id, data, selected }) => {
+  const instance = useReactFlow();
+  const { clients } = useContext(ClientContext) as ClientContextType;
+
+  let initialValues = useMemo(() => {
+    return {
+      client: data.client ? data.client : "-",
+      job: data.job ? data.job : "",
+      endpoint: data.endpoint ? data.endpoint : "",
+    };
+  }, []);
+
+  const handleChange = useCallback((name: string, value: string) => {
+    instance.setNodes((nodes) =>
+      nodes.map((node) => {
+        if (node.id === id) {
+          node.data = {
+            ...node.data,
+            [name]: value,
+          };
+        }
+
+        return node;
+      }),
+    );
+  }, []);
+
+  useEffect(() => {
+    handleChange("client", initialValues.client);
+    handleChange("job", initialValues.job);
+    handleChange("endpoint", initialValues.endpoint);
+  }, []);
+
+  let classNames = `${styles.customNode} `;
+  if (selected) {
+    classNames = classNames + `${styles.selected}`;
+  }
+
+  const removeNode = useCallback((id: string) => {
+    const node = instance.getNode(id);
+    if (node === undefined) {
+      return;
+    }
+    instance.deleteElements({
+      edges: getConnectedEdges([node], []),
+      nodes: [node],
+    });
+  }, []);
+
+  return (
+    <div className={classNames}>
+      <Handle type="target" position={Position.Left} id={id} />
+      <Handle type="source" position={Position.Right} id={id} />
+
+      <div className=" grid grid-cols-1 gap-x-6 gap-y-2">
+        <h2 className="text-slate-400 font-normal">Bacalhau Destination</h2>
+        <button
+          onClick={() => {
+            if (confirm("Are you sure you want to delete this node?")) {
+              removeNode(id);
+            }
+          }}
+          type="button"
+          className="absolute right-1 top-1 rounded bg-red-200 text-white shadow-sm hover:bg-red-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-800"
+          title="delete"
+        >
+          <XMarkIcon className="h-5 w-5" aria-hidden="true" />
+        </button>
+        <Select
+          name="client"
+          label="Client"
+          placeholder="Pick one"
+          defaultValue={initialValues.client}
+          options={(clients || []).map((c) => c.id)}
+          onChange={(value) => {
+            handleChange("client", value || "");
+          }}
+        />
+        <Select
+          name="job"
+          label="Job"
+          placeholder="Pick one"
+          defaultValue={initialValues.job}
+          options={["Sample"]}
+          onChange={(value) => {
+            handleChange("job", value || "");
+          }}
+        />
+        <TextInput
+          name="endpoint"
+          label="Endpoint"
+          placeholder={initialValues.endpoint}
+          defaultValue={initialValues.endpoint}
+          onChange={(event) => {
+            handleChange("endpoint", event.currentTarget.value)
+          }}
+        />
+      </div>
+    </div>
+  );
+});
+
 const HelloWorldDestinationNode: FC<NodeProps> = memo(({ id, data, selected }) => {
   const instance = useReactFlow();
   const { clients } = useContext(ClientContext) as ClientContextType;
@@ -1324,4 +1642,7 @@ export {
   PostgresSourceNode,
   HelloWorldSourceNode,
   HelloWorldDestinationNode,
-};
+  BacalhauNode,
+  BacalhauSourceNode,
+  BacalhauDestinationNode,
+}

--- a/pipe/runtime/Cargo.toml
+++ b/pipe/runtime/Cargo.toml
@@ -12,7 +12,7 @@ tokio = []
 [dependencies]
 futures = "0.3"
 arrow = "42"
-tokio = { version = "1", features=["full"] }
+tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"
 tokio-stream = "0.1"
 serde_json = "1"
@@ -22,7 +22,7 @@ log = "0.4"
 rdkafka = "0.34.0"
 
 ## fixme
-reqwest = { version = "0.11" }
+reqwest = { version = "0.11", features = ["json"] }
 base64 = { version = "0.21" }
 bytes = "1.5"
 
@@ -30,4 +30,6 @@ bytes = "1.5"
 stub = { path = "../section/section_impls/stub/" }
 sqlite_connector = { path = "../section/section_impls/sqlite_connector/" }
 kafka = { path = "../section/section_impls/kafka/" }
+bacalhau = { path = "../section/section_impls/bacalhau/" }
 sqlite_physical_replication = { path = "../section/section_impls/sqlite_physical_replication/" }
+async-watcher = "0.2.0"

--- a/pipe/runtime/src/sections/bacalhau/destination.rs
+++ b/pipe/runtime/src/sections/bacalhau/destination.rs
@@ -1,0 +1,67 @@
+//! Bacalhau Destination Ssection
+//!
+//! Receives messages from source sections, and after extracting
+//! information from the RecordBatch, posts it to the configured
+//! endpoint, to be processed by an external process.
+use crate::config::Map;
+use crate::types::{DynSection, DynSink, DynStream, SectionError};
+
+use futures::StreamExt;
+use std::future::Future;
+use std::pin::Pin;
+use stub::Stub;
+
+use bacalhau::{destination::Bacalhau, BacalhauPayload};
+use section::{Section, SectionChannel};
+
+#[derive(Debug)]
+pub struct BacalhauAdapter {
+    inner: Bacalhau,
+}
+
+impl<SectionChan: SectionChannel + Send + 'static> Section<DynStream, DynSink, SectionChan>
+    for BacalhauAdapter
+{
+    // FIXME: define proper error
+    type Error = SectionError;
+    type Future = Pin<Box<dyn Future<Output = Result<(), Self::Error>> + Send>>;
+
+    fn start(
+        self,
+        input: DynStream,
+        _output: DynSink,
+        section_channel: SectionChan,
+    ) -> Self::Future {
+        Box::pin(async move {
+            let input = input.map(|message: section::Message<crate::message::RecordBatch>| {
+                let bac: BacalhauPayload = (&message.payload.0).try_into().unwrap();
+                bacalhau::Message::new(message.origin, bac, message.ack)
+            });
+            let output = Stub::<bacalhau::Message, SectionError>::new();
+            self.inner.start(input, output, section_channel).await
+        })
+    }
+}
+
+pub fn constructor<S: SectionChannel>(
+    config: &Map,
+) -> Result<Box<dyn DynSection<S>>, SectionError> {
+    let job = config
+        .get("job")
+        .ok_or("bacalhau section requires 'job'")?
+        .as_str()
+        .ok_or("'job' should be a string")?;
+    let endpoint = config
+        .get("endpoint")
+        .ok_or("bacalhau section requires 'endpoint'")?
+        .as_str()
+        .ok_or("'endpoint' should be a string")?;
+    let outputs = config
+        .get("outputs")
+        .ok_or("bacalhau section requires 'outputs'")?
+        .as_str()
+        .ok_or("'outputs' should be a string")?;
+    Ok(Box::new(BacalhauAdapter {
+        inner: Bacalhau::new(job, endpoint, outputs),
+    }))
+}

--- a/pipe/runtime/src/sections/bacalhau/mod.rs
+++ b/pipe/runtime/src/sections/bacalhau/mod.rs
@@ -1,0 +1,7 @@
+pub mod destination;
+pub mod source;
+
+use bacalhau::BacalhauPayload;
+use section::Message as _Message;
+
+pub type Message = _Message<BacalhauPayload>;

--- a/pipe/runtime/src/sections/bacalhau/source.rs
+++ b/pipe/runtime/src/sections/bacalhau/source.rs
@@ -1,0 +1,69 @@
+//! Bacalhau Source Section
+//!
+//! Monitors the configured folder on disk for file events, and then
+//! after reading the entire JSON blob into a messages, sends it on
+//! to a receiving destination section.
+
+use crate::{
+    config::Map,
+    types::{DynSection, DynSink, DynStream, SectionError, SectionFuture},
+};
+
+use arrow::record_batch::RecordBatch;
+use bacalhau::source::Bacalhau;
+use futures::SinkExt;
+use section::{Section, SectionChannel};
+use stub::Stub;
+
+#[derive(Debug)]
+pub struct BacalhauAdapter {
+    inner: Bacalhau,
+}
+
+impl<SectionChan: SectionChannel + Send + 'static> Section<DynStream, DynSink, SectionChan>
+    for BacalhauAdapter
+{
+    // FIXME: define proper error
+    type Error = SectionError;
+    type Future = SectionFuture;
+
+    fn start(
+        self,
+        _input: DynStream,
+        output: DynSink,
+        section_channel: SectionChan,
+    ) -> Self::Future {
+        Box::pin(async move {
+            let input = Stub::<bacalhau::Message, SectionError>::new();
+            let output = output.with(|message: bacalhau::Message| async {
+                let payload: RecordBatch = message.payload.try_into()?;
+                let message = section::Message::new(message.origin, payload, message.ack);
+                Ok(message)
+            });
+            self.inner.start(input, output, section_channel).await
+        })
+    }
+}
+
+pub fn constructor<S: SectionChannel>(
+    config: &Map,
+) -> Result<Box<dyn DynSection<S>>, SectionError> {
+    let job = config
+        .get("job")
+        .ok_or("bacalhau section requires 'job'")?
+        .as_str()
+        .ok_or("'job' should be a string")?;
+    let endpoint = config
+        .get("endpoint")
+        .ok_or("bacalhau section requires 'endpoint'")?
+        .as_str()
+        .ok_or("'endpoint' should be a string")?;
+    let outputs = config
+        .get("outputs")
+        .ok_or("bacalhau section requires 'outputs'")?
+        .as_str()
+        .ok_or("'outputs' should be a string")?;
+    Ok(Box::new(BacalhauAdapter {
+        inner: Bacalhau::new(job, endpoint, outputs),
+    }))
+}

--- a/pipe/runtime/src/sections/hello_world/destination.rs
+++ b/pipe/runtime/src/sections/hello_world/destination.rs
@@ -2,7 +2,7 @@
 //!
 //! Upon receipt of a message, this section will log "Hello, World!" + the message received. It
 //! then forwards the message on to the next section.
-use futures::{FutureExt, Sink, Stream, StreamExt, SinkExt};
+use futures::{FutureExt, Sink, SinkExt, Stream, StreamExt};
 use section::{Command, Section, SectionChannel};
 use std::future::Future;
 
@@ -79,6 +79,8 @@ where
     }
 }
 
-pub fn constructor<S: SectionChannel>(_config: &Map) -> Result<Box<dyn DynSection<S>>, SectionError> {
+pub fn constructor<S: SectionChannel>(
+    _config: &Map,
+) -> Result<Box<dyn DynSection<S>>, SectionError> {
     Ok(Box::new(HelloWorld::new()))
 }

--- a/pipe/runtime/src/sections/mod.rs
+++ b/pipe/runtime/src/sections/mod.rs
@@ -1,5 +1,6 @@
+pub mod bacalhau;
 pub mod hello_world;
+pub mod kafka;
 pub mod mycelial_server;
 pub mod sqlite_connector;
-pub mod kafka;
 pub mod sqlite_physical_replication;

--- a/pipe/section/section_impls/bacalhau/Cargo.toml
+++ b/pipe/section/section_impls/bacalhau/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "bacalhau"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+section = { path = "../../" }
+futures = "0.3"
+reqwest = { version = "0.11.22", features = ["json"] }
+tokio = "1.33.0"
+tokio-stream = { version = "0.1.14", features = ["tokio-util"] }
+async-watcher = "0.2.0"
+serde = "1"
+serde_json = "1"
+arrow = "42"
+arrow-json = "42"

--- a/pipe/section/section_impls/bacalhau/src/destination.rs
+++ b/pipe/section/section_impls/bacalhau/src/destination.rs
@@ -1,0 +1,111 @@
+//! Bacalhau Destination Section
+//!
+//! Receives messages from source sections, and after extracting
+//! information from the RecordBatch, posts it to the configured
+//! endpoint, to be processed by an external process.
+
+use super::{Message, StdError};
+use std::pin::{pin, Pin};
+
+use section::Section;
+
+use futures::{Future, FutureExt, Sink, SinkExt, Stream, StreamExt};
+use reqwest;
+use section::{Command, SectionChannel};
+
+impl Default for Bacalhau {
+    fn default() -> Self {
+        Self::new("Sample", "", "")
+    }
+}
+
+#[derive(Debug)]
+pub struct Bacalhau {
+    pub job: String,
+    pub endpoint: String,
+    pub outputs: String,
+}
+
+impl Bacalhau {
+    pub fn new(
+        job: impl Into<String>,
+        endpoint: impl Into<String>,
+        outputs: impl Into<String>,
+    ) -> Self {
+        Self {
+            job: job.into(),
+            endpoint: endpoint.into(),
+            outputs: outputs.into(),
+        }
+    }
+
+    pub async fn submit_job(
+        &self,
+        id: impl Into<String>,
+        msg: impl Into<String>,
+    ) -> Result<(), StdError> {
+        let _json_response: serde_json::Value = reqwest::Client::new()
+            .post(self.endpoint.clone())
+            .json(&serde_json::json!({
+                "id": id.into(),
+                "message": msg.into(),
+            }))
+            .send()
+            .await?
+            .json()
+            .await?;
+
+        Ok(())
+    }
+
+    pub async fn enter_loop<Input, Output, SectionChan>(
+        self,
+        input: Input,
+        output: Output,
+        mut section_chan: SectionChan,
+    ) -> Result<(), StdError>
+    where
+        Input: Stream<Item = Message> + Send + 'static,
+        Output: Sink<Message, Error = StdError> + Send + 'static,
+        SectionChan: SectionChannel + Send + Sync + 'static,
+    {
+        let mut input = pin!(input.fuse());
+        let mut output = pin!(output);
+        loop {
+            futures::select_biased! {
+                cmd = section_chan.recv().fuse() => {
+                    if let Command::Stop = cmd? {
+                        return Ok(())
+                    }
+                }
+                msg = input.next() => {
+                    let msg = match msg {
+                        Some(msg) => msg,
+                        None => Err("input stream closed")?
+                    };
+
+                    let payload = &msg.payload;
+                    let origin = &msg.origin;
+                    self.submit_job(&payload.id, &payload.message).await?;
+
+                    section_chan.log(&format!("Message from '{:?}' received! {:?}", origin, payload)).await?;
+                    output.send(msg).await?;
+                },
+            }
+        }
+    }
+}
+
+impl<Input, Output, SectionChan> Section<Input, Output, SectionChan> for Bacalhau
+where
+    Input: Stream<Item = Message> + Send + 'static,
+    Output: Sink<Message, Error = StdError> + Send + 'static,
+    SectionChan: SectionChannel + Send + 'static,
+{
+    type Error = StdError;
+    type Future = Pin<Box<dyn Future<Output = Result<(), Self::Error>> + Send + 'static>>;
+
+    fn start(self, input: Input, output: Output, command: SectionChan) -> Self::Future {
+        Box::pin(async move { self.enter_loop(input, output, command).await })
+    }
+}

--- a/pipe/section/section_impls/bacalhau/src/lib.rs
+++ b/pipe/section/section_impls/bacalhau/src/lib.rs
@@ -1,0 +1,89 @@
+pub mod destination;
+pub mod source;
+
+type StdError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+use std::sync::Arc;
+
+use arrow::{
+    array::{ArrayRef, StringArray},
+    datatypes::{DataType, Field, Schema},
+    error::ArrowError,
+    record_batch::RecordBatch,
+};
+use section::Message as _Message;
+use serde::{Deserialize, Serialize};
+pub type Message = _Message<BacalhauPayload>;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BacalhauPayload {
+    pub id: String,
+    pub message: String,
+}
+
+impl BacalhauPayload {
+    fn new(id: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            message: message.into(),
+        }
+    }
+}
+
+impl TryFrom<RecordBatch> for BacalhauPayload {
+    type Error = StdError;
+
+    fn try_from(batch: RecordBatch) -> Result<Self, Self::Error> {
+        Self::try_from(&batch)
+    }
+}
+
+impl TryFrom<&RecordBatch> for BacalhauPayload {
+    type Error = StdError;
+
+    fn try_from(batch: &RecordBatch) -> Result<Self, Self::Error> {
+        // fudge: to json and pull 'id' and 'message'
+        let json_rows = arrow_json::writer::record_batches_to_json_rows(&[&batch]).unwrap();
+        let row = json_rows.first().unwrap();
+
+        let Some(id) = row.get("id").map(|v| v.as_str()) else {
+            return Err("missing 'id'".into());
+        };
+        let Some(message) = row.get("message").map(|v| v.as_str()) else {
+            return Err("missing 'message'".into());
+        };
+
+        Ok(Self {
+            id: id.unwrap().into(),
+            message: message.unwrap().into(),
+        })
+    }
+}
+
+impl TryInto<RecordBatch> for &BacalhauPayload {
+    // FIXME: proper conv error type
+    type Error = ArrowError;
+
+    fn try_into(self) -> Result<RecordBatch, Self::Error> {
+        let schema: Arc<Schema> = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, true),
+            Field::new("message", DataType::Utf8, true),
+        ]));
+        let columns: Vec<ArrayRef> = vec![
+            Arc::new(StringArray::from(vec![self.id.clone()])),
+            Arc::new(StringArray::from(vec![self.message.clone()])),
+        ];
+        let r = RecordBatch::try_new(schema, columns)?;
+
+        Ok(r)
+    }
+}
+
+impl TryInto<RecordBatch> for BacalhauPayload {
+    // FIXME: proper conv error type
+    type Error = ArrowError;
+
+    fn try_into(self) -> Result<RecordBatch, Self::Error> {
+        (&self).try_into()
+    }
+}

--- a/pipe/section/section_impls/bacalhau/src/source.rs
+++ b/pipe/section/section_impls/bacalhau/src/source.rs
@@ -1,0 +1,105 @@
+//! Bacalhau Source Section
+//!
+//! Monitors the configured folder on disk for file events, and then
+//! after reading the entire JSON blob into a messages, sends it on
+//! to a receiving destination section.
+use super::{BacalhauPayload, Message, StdError};
+
+use std::pin::Pin;
+use std::time::Duration;
+use std::{path::PathBuf, pin::pin};
+
+use async_watcher::{notify::RecursiveMode, AsyncDebouncer};
+use futures::{Future, FutureExt, Sink, SinkExt, Stream};
+use section::{Command, Section, SectionChannel};
+
+#[derive(Debug)]
+pub struct Bacalhau {
+    job: String,
+    endpoint: String,
+    outputs: String,
+}
+
+impl Default for Bacalhau {
+    fn default() -> Self {
+        Self::new("", "", "")
+    }
+}
+
+impl Bacalhau {
+    pub fn new(
+        job: impl Into<String>,
+        endpoint: impl Into<String>,
+        outputs: impl Into<String>,
+    ) -> Self {
+        Self {
+            job: job.into(),
+            endpoint: endpoint.into(),
+            outputs: outputs.into(),
+        }
+    }
+
+    pub async fn enter_loop<Input, Output, SectionChan>(
+        self,
+        _input: Input,
+        output: Output,
+        mut section_chan: SectionChan,
+    ) -> Result<(), StdError>
+    where
+        Input: Stream<Item = Message> + Send + 'static,
+        Output: Sink<Message, Error = StdError> + Send + 'static,
+        SectionChan: SectionChannel + Send + 'static,
+    {
+        let mut output = pin!(output);
+        let (mut debouncer, mut file_events) =
+            AsyncDebouncer::new_with_channel(Duration::from_secs(1), Some(Duration::from_secs(1)))
+                .await?;
+
+        let path: PathBuf = self.outputs.into();
+        debouncer
+            .watcher()
+            .watch(&path, RecursiveMode::Recursive)
+            .unwrap();
+
+        loop {
+            futures::select_biased! {
+                cmd = section_chan.recv().fuse() => {
+                    if let Command::Stop = cmd? {
+                        return Ok(())
+                    }
+                }
+                event = file_events.recv().fuse() => {
+                    // TODO: It's like xmas..
+                    let payloads: Vec<_> = event.unwrap().ok().unwrap().iter().map(
+                        |e| {
+                            let bytes = std::fs::read(&e.path).unwrap();
+                            let bacalhau_payload: BacalhauPayload = serde_json::from_slice(&bytes).unwrap();
+                            Message::new("bacalhau", bacalhau_payload, None)
+                        }
+                    ).collect();
+
+                    for payload in payloads {
+                        section_chan.log(&format!("sending message: '{:?}'", &payload)).await?;
+                        output.send(payload).await.ok();
+
+                        // TODO: delete the file
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<Input, Output, SectionChan> Section<Input, Output, SectionChan> for Bacalhau
+where
+    Input: Stream<Item = Message> + Send + 'static,
+    Output: Sink<Message, Error = StdError> + Send + 'static,
+    SectionChan: SectionChannel + Send + 'static,
+{
+    type Error = StdError;
+    type Future = Pin<Box<dyn Future<Output = Result<(), Self::Error>> + Send + 'static>>;
+
+    fn start(self, input: Input, output: Output, command: SectionChan) -> Self::Future {
+        Box::pin(async move { self.enter_loop(input, output, command).await })
+    }
+}


### PR DESCRIPTION
This PR implements a section for the [Bacalhau platform](https://www.bacalhau.org/), allowing it to be used in pipelines in a similar fashion to "mycelial server" (e.g. a single node implementing source+destination). This can be used to implement filters/transformers so that the original message can be changed, or a new message generated in response to the processing in the bacalhau job. 

By configuring the node in the UI, the node is provided with an 'endpoint' parameter, and an 'outputs' parameter.  

When receiving a message at the bacalhau destination, the message is posted as JSON to the address/post/path described in the endpoint parameter.  Once it has replied a response representing success, the destination considers its work done. 

The process listening to the 'endpoint' parameter, a long-running Bacalhau job, will perform its processing on the data it receives.  When it has generated a response, it will write the resulting JSON text to a file in the directory described by 'outputs'. 

The bacalhau source section monitors the folder specified by the 'outputs' parameter.  When a new file appears in the directory, it is loaded into a message and sent on to the configured destination which is expecting to receive the output from the bacalhau job.
